### PR TITLE
Adding error handling and retry mechanism for Wemos.ino sketch

### DIFF
--- a/examples/Wemos/Wemos.ino
+++ b/examples/Wemos/Wemos.ino
@@ -33,7 +33,10 @@ hackAIR sensor(SENSOR_SDS011);
 DHT dht(D4, DHT11);
 
 // How often to measure (in minutes)
-const unsigned long minutes_time_interval = 5;
+const unsigned long minutes_time_interval = 5; // minutes
+
+// How long to try for a valid measurement
+const unsigned long retry_period_s = 10; // s
 
 // Setup ADC to measure Vcc (battery voltage)
 ADC_MODE(ADC_VCC);
@@ -80,13 +83,24 @@ void loop() {
     Serial.print(".");
   }
 
-  // Measure data
-  sensor.clearData(data);
-  sensor.readAverageData(data, 60); // 60 averages
+  Serial.println("Doing measurement");
+  unsigned long timestamp = millis();
+  while (data.error != 0) {
+    if(millis() > timestamp + (retry_period_s * 1000)) {
+      Serial.println("Tried too long, giving up.");
+      break;
+    }
+    sensor.turnOn();
+    delay(100);
+    sensor.readAverageData(data, 60); // 60 averages
+    yield();
+  }
 
   // Compensate for humidity
-  float humidity = dht.readHumidity();
-  sensor.humidityCompensation(data, humidity);
+  if (data.error == 0) {  
+    float humidity = dht.readHumidity();
+    sensor.humidityCompensation(data, humidity);
+  }
 
   // Send the data to the hackAIR server
   String dataJson = "{\"reading\":{\"PM2.5_AirPollutantValue\":\"";
@@ -122,17 +136,17 @@ void loop() {
     }
     client.stop();
   }
-  delay(1000);
-
+  
   // Turn off sensor and go to sleep
   sensor.turnOff();
+  Serial.println("");
+  Serial.println("Sensor Off");
   unsigned long current_millis = millis();
   while (current_millis <
          (previous_millis + (minutes_time_interval * 60 * 1000))) {
     delay(10000);
     current_millis = millis();
-    Serial.println(current_millis);
+    Serial.print(".");
   }
   previous_millis = current_millis;
-  sensor.turnOn();
 }

--- a/examples/Wemos/Wemos.ino
+++ b/examples/Wemos/Wemos.ino
@@ -84,6 +84,7 @@ void loop() {
   }
 
   Serial.println("Doing measurement");
+  sensor.clearData(data);
   unsigned long timestamp = millis();
   while (data.error != 0) {
     if(millis() > timestamp + (retry_period_s * 1000)) {

--- a/examples/Wemos/Wemos.ino
+++ b/examples/Wemos/Wemos.ino
@@ -96,9 +96,9 @@ void loop() {
   dataJson += "\"},\"battery\":\"";
   dataJson += vdd;
   dataJson += "\",\"tamper\":\"";
-  dataJson += "0";
+  dataJson += data.tamper;
   dataJson += "\",\"error\":\"";
-  dataJson += "0";
+  dataJson += data.error;
   dataJson += "\"}";
   if (client.connect("api.hackair.eu", 443)) {
     Serial.println("connected");

--- a/examples/Wemos/Wemos.ino
+++ b/examples/Wemos/Wemos.ino
@@ -98,8 +98,8 @@ void loop() {
   }
 
   // Compensate for humidity
-  if (data.error == 0) {  
-    float humidity = dht.readHumidity();
+  float humidity = dht.readHumidity();
+  if (data.error == 0 && !isnan(humidity)) {
     sensor.humidityCompensation(data, humidity);
   }
 

--- a/src/hackair.cpp
+++ b/src/hackair.cpp
@@ -163,7 +163,7 @@ void hackAIR::readAverageData(hackAirData &data, uint8_t n) {
 void hackAIR::clearData(hackAirData &data) {
     data.pm25 = 0;
     data.pm10 = 0;
-    data.error = 0;
+    data.error = 1;
     data.tamper = 0;
     data.battery = 0;
 }


### PR DESCRIPTION
This Pull Request consists of three improvements:

- As already stated for the WifiShield Sketch in https://github.com/hackair-project/hackAir-Arduino/pull/12, a time-based retry mechanism for the sensor measurement has been implemented.
- The `error` and `tamper` fields of the data struct are actually written into the JSON String (solving https://github.com/hackair-project/hackAir-Arduino/issues/13)
- The humidity correction is only done when the sensor measurement and the DHT humidity measurements were successful. (solving https://github.com/hackair-project/hackAir-Arduino/issues/14)